### PR TITLE
submodule管理の改善とprepareスクリプトの追加

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Update submodules
-        run: git submodule update --remote
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "node scripts/index.ts",
     "format": "prettier . --write",
-    "test": "tsc --noEmit && node --test 'scripts/**/*.test.ts'"
+    "test": "tsc --noEmit && node --test 'scripts/**/*.test.ts'",
+    "prepare": "git submodule update --init --recursive"
   },
   "dependencies": {
     "@types/gitconfiglocal": "2.0.3",


### PR DESCRIPTION
## 概要
- GitHub Actionsワークフローから手動のsubmodule updateステップを削除
- package.jsonにprepareスクリプトを追加してsubmoduleの初期化・更新を自動化

## 詳細
- ワークフローの手動submodule updateステップが冗長だったため削除
- npm installの実行時に自動的にsubmoduleが初期化・更新されるようprepareスクリプトを追加
- これによりCI/CDプロセスが簡潔になり、ローカル開発でも自動的にsubmoduleが管理される

## テスト計画
- [ ] ワークフローが正常に実行されることを確認
- [ ] submoduleが適切に初期化・更新されることを確認
- [ ] npm installでprepareスクリプトが実行されることを確認