### PR TITLE
__esModuleとdefaultエクスポートをREADME出力から除外

### DIFF
--- a/scripts/renderers.ts
+++ b/scripts/renderers.ts
@@ -109,7 +109,7 @@ export async function renderReadme({
   const byUserPackage = await groupByUserPackage(namedImportsStats);
   const byModuleExportName = groupByModuleExportName(
     namedImportsStats,
-    new Set(Object.keys(await import(targetModuleName))),
+    new Set(Object.keys(await import(targetModuleName)).filter(key => key !== '__esModule' && key !== 'default')),
   );
 
   const columns: string[] = await (async () => {
@@ -195,7 +195,7 @@ export async function renderByModuleExportName({
 }) {
   const byModuleExportName = groupByModuleExportName(
     namedImportsStats,
-    new Set(Object.keys(await import(targetModuleName))),
+    new Set(Object.keys(await import(targetModuleName)).filter(key => key !== '__esModule' && key !== 'default')),
   );
   const byReferenced = new Map(
     Array.from(byModuleExportName).filter(


### PR DESCRIPTION
## 概要
- README.mdの表に不要な`__esModule`と`default`エントリが表示される問題を修正
- antdモジュールのキー取得時にESモジュール互換プロパティを除外するフィルターを追加

## 変更内容
- `scripts/renderers.ts`の`renderReadme`と`renderByModuleExportName`関数で`Object.keys()`結果をフィルタリング
- `__esModule`と`default`キーを除外することで、実際のAnt Designコンポーネントのみを表示

## テスト計画
- [ ] ビルドが正常に実行されることを確認
- [ ] README.mdから`__esModule`と`default`の行が削除されることを確認
- [ ] 他のAnt Designコンポーネントは正常に表示されることを確認