### PR TITLE
ユーザーパッケージ設定をオブジェクト形式にリファクタリング

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -20,25 +20,15 @@ export const rootDirectoryPath = path.join(import.meta.dirname, '..');
 export const userPackageNameMap = new Map<string, string>();
 
 // TODO: set the display name of the user packages
-// prettier-ignore
-for (const [directoryPath, name] of [
-  [
-    '../user-repositories/internal-library-reference-stats-user-a/systems/plum/packages/front',
+for (const [directoryPath, name] of Object.entries({
+  '../user-repositories/internal-library-reference-stats-user-a/systems/plum/packages/front':
     '梅',
-  ],
-  [
-    '../user-repositories/internal-library-reference-stats-user-a/systems/shiratama/packages/front',
+  '../user-repositories/internal-library-reference-stats-user-a/systems/shiratama/packages/front':
     '白玉',
-  ],
-  [
-    '../user-repositories/internal-library-reference-stats-user-a/systems/vinegar/packages/front',
+  '../user-repositories/internal-library-reference-stats-user-a/systems/vinegar/packages/front':
     '酢',
-  ],
-  [
-    '../user-repositories/internal-library-reference-stats-user-b',
-    'User B',
-  ],
-] satisfies [string, string][]) {
+  '../user-repositories/internal-library-reference-stats-user-b': 'User B',
+})) {
   const absolutePath = path.join(import.meta.dirname, directoryPath);
   userPackageNameMap.set(absolutePath, name);
 }


### PR DESCRIPTION
## 概要
- ユーザーパッケージの設定部分を配列形式からオブジェクト形式にリファクタリング
- `Object.entries()`を使用してコードを簡潔化
- 可読性とメンテナンス性を向上

## 変更内容
- `scripts/config.ts`のユーザーパッケージマッピング設定を改善
- 配列のタプル形式からオブジェクト形式に変更
- prettier-ignoreコメントが不要になり、コードがより自然な形に

## テスト計画
- [ ] 既存の機能が正常に動作することを確認
- [ ] ユーザーパッケージ名のマッピングが正しく動作することを確認
- [ ] 設定値が変更前と同じであることを確認